### PR TITLE
Fix typos in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,13 +7,13 @@ It includes following parts of experiments in the paper:
 - `Arithmetic-Operation-Only Magnifier Gadget`:  This is an magnifier gadget that doesn't rely on any cache accesses to magnify the timing difference. For more details, please refer to  section 6.4 of the paper.
 - `spectre.js`:  This is a JavaScript demo for SpectreBack attack. For more details, please refer to  section 7.3 & 6.2 of the paper.
 
-- `PRIME-SCOPE-hackyracer`:  This is a [Prime+Scope](https://antoonpurnal.github.io/files/pdf/PrimeScope.pdf) based eviction set profiling algoritm whose timer is intergrated with Hacky Racer.
+- `PRIME-SCOPE-hackyracer`:  This is a [Prime+Scope](https://antoonpurnal.github.io/files/pdf/PrimeScope.pdf) based eviction set profiling algorithm whose timer is integrated with Hacky Racer.
 
-Please follow intructions in each folder's README.md to run each experiment.
+Please follow instructions in each folder's README.md to run each experiment.
 
 The experiment would get more stable result if the CPU frequency is set to a stable value. You can use the [cpuf](https://askubuntu.com/questions/1141605/gui-or-simple-bash-script-to-throttle-the-cpu/1142671#1142671) script here to fix the frequency.
 - install yad package: `apt-get install yad`
 - execute the cpuf.sh: `chmod a+x ./cpuf; sudo ./cpuf`
-- set the new minimal and maximum frequency to the same value (between allowable minimun and maximun frequency); Then if the current frequency equals to that value, the frequency is fixed successfully. Some frequency value might be denied depending on CPU model. Therefore, please try different values, such as 2GHZ, 1GHz, 1.5GHz, until it works. 
+- set the new minimal and maximum frequency to the same value (between allowable minimum and maximum frequency); Then if the current frequency equals to that value, the frequency is fixed successfully. Some frequency value might be denied depending on CPU model. Therefore, please try different values, such as 2GHZ, 1GHz, 1.5GHz, until it works.
 
 All files and folders under this directory follow the Apache 2.0 License located in this directory.


### PR DESCRIPTION
## Summary
- correct several spelling errors in README

## Testing
- `npm test` *(fails: missing package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_685cc5d59fec832cb406efd7033af689