### PR TITLE
Clarify cpuf usage in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Please follow instructions in each folder's README.md to run each experiment.
 
 The experiment would get more stable result if the CPU frequency is set to a stable value. You can use the [cpuf](https://askubuntu.com/questions/1141605/gui-or-simple-bash-script-to-throttle-the-cpu/1142671#1142671) script here to fix the frequency.
 - install yad package: `apt-get install yad`
-- execute the cpuf.sh: `chmod a+x ./cpuf; sudo ./cpuf`
+- execute the cpuf script: `chmod a+x ./cpuf; sudo ./cpuf`
 - set the new minimal and maximum frequency to the same value (between allowable minimum and maximum frequency); Then if the current frequency equals to that value, the frequency is fixed successfully. Some frequency value might be denied depending on CPU model. Therefore, please try different values, such as 2GHZ, 1GHz, 1.5GHz, until it works.
 
 All files and folders under this directory follow the Apache 2.0 License located in this directory.


### PR DESCRIPTION
## Summary
- fix README to say "execute the cpuf script" while keeping example command

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685cc6e4db68832ca9e549144050b7d2